### PR TITLE
Task.6-2 ER図に書いた各種テーブルとmodelの作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ capybara-*.html
 *.orig
 rerun.txt
 pickle-email-*.html
+erd.pdf
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :development do
   gem "web-console", ">= 3.3.0"
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "annotate"
+  gem "rails-erd"
   gem "spring"
   gem "spring-watcher-listen", "~> 2.0.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
     byebug (11.0.1)
     case_transform (0.2)
       activesupport
+    choice (0.2.0)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -155,6 +156,11 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
+    rails-erd (1.6.0)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     railties (5.2.4.1)
@@ -202,6 +208,7 @@ GEM
       rubocop (>= 0.72.0)
     rubocop-rspec (1.37.1)
       rubocop (>= 0.68.1)
+    ruby-graphviz (1.2.4)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     sass (3.7.4)
@@ -272,6 +279,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.3)
+  rails-erd
   rspec-rails
   rubocop-performance
   rubocop-rails

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,0 +1,2 @@
+class Article < ApplicationRecord
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,2 +1,5 @@
 class Article < ApplicationRecord
+  has_many :comments, dependent: :destroy
+  has_many :article_likes, dependent: :destroy
+  belongs_to :user
 end

--- a/app/models/article_like.rb
+++ b/app/models/article_like.rb
@@ -1,0 +1,3 @@
+class ArticleLike < ApplicationRecord
+  belongs_to :article
+end

--- a/app/models/article_like.rb
+++ b/app/models/article_like.rb
@@ -1,3 +1,4 @@
 class ArticleLike < ApplicationRecord
   belongs_to :article
+  belongs_to :user
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,2 +1,4 @@
 class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :article
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,2 @@
+class Comment < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,9 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User
+
+  has_many :articles, dependent: :destroy
+  has_many :comments, dependent: :destroy
+  has_many :article_likes, dependent: :destroy
+  
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,5 +11,4 @@ class User < ApplicationRecord
   has_many :articles, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
-  
 end

--- a/db/migrate/20200108062125_create_articles.rb
+++ b/db/migrate/20200108062125_create_articles.rb
@@ -1,0 +1,10 @@
+class CreateArticles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :articles do |t|
+      t.string :title
+      t.text :body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200108062455_create_comments.rb
+++ b/db/migrate/20200108062455_create_comments.rb
@@ -1,0 +1,9 @@
+class CreateComments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :comments do |t|
+      t.text :body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200108063922_create_article_likes.rb
+++ b/db/migrate/20200108063922_create_article_likes.rb
@@ -1,0 +1,10 @@
+class CreateArticleLikes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :article_likes do |t|
+      t.refereces :user, foreign_key: true
+      t.references :article, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200108063922_create_article_likes.rb
+++ b/db/migrate/20200108063922_create_article_likes.rb
@@ -1,7 +1,7 @@
 class CreateArticleLikes < ActiveRecord::Migration[5.2]
   def change
     create_table :article_likes do |t|
-      t.refereces :user, foreign_key: true
+      t.references :user, foreign_key: true
       t.references :article, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20200108065917_add_user_id_to_articles.rb
+++ b/db/migrate/20200108065917_add_user_id_to_articles.rb
@@ -1,0 +1,5 @@
+class AddUserIdToArticles < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :articles, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20200108070203_add_user_id_to_comments.rb
+++ b/db/migrate/20200108070203_add_user_id_to_comments.rb
@@ -1,0 +1,5 @@
+class AddUserIdToComments < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :comments, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20200108070235_add_article_id_to_comments.rb
+++ b/db/migrate/20200108070235_add_article_id_to_comments.rb
@@ -1,0 +1,5 @@
+class AddArticleIdToComments < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :comments, :article, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_08_053717) do
+ActiveRecord::Schema.define(version: 2020_01_08_070235) do
+
+  create_table "article_likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "article_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["article_id"], name: "index_article_likes_on_article_id"
+    t.index ["user_id"], name: "index_article_likes_on_user_id"
+  end
+
+  create_table "articles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "title"
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.bigint "article_id"
+    t.index ["article_id"], name: "index_comments_on_article_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "provider", default: "email", null: false
@@ -36,4 +64,9 @@ ActiveRecord::Schema.define(version: 2020_01_08_053717) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "article_likes", "articles"
+  add_foreign_key "article_likes", "users"
+  add_foreign_key "articles", "users"
+  add_foreign_key "comments", "articles"
+  add_foreign_key "comments", "users"
 end

--- a/spec/factories/article_likes.rb
+++ b/spec/factories/article_likes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :article_like do
+    user { "" }
+    article { nil }
+  end
+end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :article do
+    title { "MyString" }
+    body { "MyText" }
+  end
+end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :comment do
+    body { "MyText" }
+  end
+end

--- a/spec/models/article_like_spec.rb
+++ b/spec/models/article_like_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ArticleLike, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/article_like_spec.rb
+++ b/spec/models/article_like_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ArticleLike, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Article, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Article, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Comment, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 作業概要

- ER図を元にarticle, comment, article_likeのモデルとテーブルを作成
- ER図を元に外部キーカラムを追加
- テーブル間のリレーションをモデルに追加
- `rails-erb`をインストールし、実行(graphvizがインストールされていない旨のエラーが出たので、`brew install graphviz`にてインストールして解決)

![スクリーンショット 2020-01-08 23 34 59](https://user-images.githubusercontent.com/50073648/71986269-860d5200-326f-11ea-96fd-c79e05c8824d.png)

