### PR TITLE
Task.7-3 記事一覧の実装まで

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,0 +1,3 @@
+class Api::V1::ApiController < ApplicationController
+    include DeviseTokenAuth::Concerns::SetUserByToken
+end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,3 +1,3 @@
 class Api::V1::ApiController < ApplicationController
-    include DeviseTokenAuth::Concerns::SetUserByToken
+  include DeviseTokenAuth::Concerns::SetUserByToken
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::ArticlesController < Api::V1::ApiController
+    def index
+        articles = Article.all
+        render json: articles
+      end
+end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ArticlesController < Api::V1::ApiController
-    def index
-        articles = Article.all
-        render json: articles
-      end
+  def index
+    articles = Article.all
+    render json: articles
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,8 @@ class User < ApplicationRecord
   include DeviseTokenAuth::Concerns::User
 
   validates :name, presence: true
-  #deviseにおいて定義されているemailの形式 @@email_regexp = /\A[^@\s]+@[^@\s]+\z/
-  #deviseにおいて定義されているpasswordの長さ @@password_length = 6..128
+  # deviseにおいて定義されているemailの形式 @@email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  # deviseにおいて定義されているpasswordの長さ @@password_length = 6..128
 
   has_many :articles, dependent: :destroy
   has_many :comments, dependent: :destroy

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,0 +1,4 @@
+class ArticleSerializer < ActiveModel::Serializer
+  attributes :id, :title, :body
+  belongs_to :user
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,4 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :name
+  has_meny :articles
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,4 +1,4 @@
 class UserSerializer < ActiveModel::Serializer
   attributes :id, :name
-  has_meny :articles
+  has_many :articles
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  namespace :api,format:"json" do
+  namespace :api, format: "json" do
     namespace :v1 do
       resources :articles
       mount_devise_token_auth_for "User", at: "auth"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for "User", at: "auth"
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api,format:"json" do
+    namespace :v1 do
+      resources :articles
+      mount_devise_token_auth_for "User", at: "auth"
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe User, type: :model do
 
       context "同一のemailが存在する時" do
         before { create(:user, email: "miyazawa@example.com") }
+
         let(:user) { build(:user, email: "miyazawa@example.com") }
         it "エラーする(has already been taken)" do
           user.valid?

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,8 +1,9 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /api/v1/articles" do
-    subject {get(api_v1_articles_path)}
+    subject { get(api_v1_articles_path) }
+
     before do
       create_list(:article, 3)
     end
@@ -13,7 +14,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       expect(res.length).to eq 3
       expect(res[0].keys).to eq ["id", "title", "body", "user"]
       expect(res[0]["user"].keys).to eq ["id", "name"]
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       expect(res.length).to eq 3
       expect(res[0].keys).to eq ["id", "title", "body", "user"]
       expect(res[0]["user"].keys).to eq ["id", "name"]
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Articles", type: :request do
+  describe "GET /api/v1/articles" do
+    subject {get(api_v1_articles_path)}
+    before do
+      create_list(:article, 3)
+    end
+
+    it "記事の一覧が取得できる" do
+      subject
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
+      expect(res[0].keys).to eq ["id", "title", "body", "user"]
+      expect(res[0]["user"].keys).to eq ["id", "name"]
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,9 @@ RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true unless meta.key?(:aggregate_failures)
+  end
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods


### PR DESCRIPTION
## 作業概要
- APIルーティング実装（`bundle exec rails routes | grep articles `で確認）
- api_controllerの実装(/app/controllers/api/v1/api_controller.rb)
- articles controller作成・indexアクション実装
- serializerファイルの作成・実装(userについてはidと名前のみ返すようにした)
- request spec実装(`bundle exec rails g rspec:integration api/v1/Article`)
- bundle exec rubocop -a実行