### PR TITLE
Task.9-1 新規登録 API の実装

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,9 +1,9 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
-    def sign_up_params
-        params.permit(:name, :email, :password, :password_confirmation)
-      end
-    
-      def account_update_params
-        params.permit(:name, :email)
-      end
+  def sign_up_params
+    params.permit(:name, :email, :password, :password_confirmation)
+    end
+
+  def account_update_params
+    params.permit(:name, :email)
+  end
 end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+    def sign_up_params
+        params.permit(:name, :email, :password, :password_confirmation)
+      end
+    
+      def account_update_params
+        params.permit(:name, :email)
+      end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,7 @@ module QiitaClone
     end
 
     config.api_only = true
+    config.middleware.use ActionDispatch::Flash
 
     # Don't generate system test files.
     config.generators.system_tests = nil

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  config.headers_names = {:'access-token' => 'access-token',
-                          :'client' => 'client',
-                          :'expiry' => 'expiry',
-                          :'uid' => 'uid',
-                          :'token-type' => 'token-type' }
+  config.headers_names = { 'access-token': "access-token",
+                           'client': "client",
+                           'expiry': "expiry",
+                           'uid': "uid",
+                           'token-type': "token-type" }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  config.token_lifespan = 1.month
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
+  config.headers_names = {:'access-token' => 'access-token',
+                          :'client' => 'client',
+                          :'expiry' => 'expiry',
+                          :'uid' => 'uid',
+                          :'token-type' => 'token-type' }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :articles
       mount_devise_token_auth_for "User", at: "auth", controllers: {
-        registrations: 'api/v1/auth/registrations'
+        registrations: "api/v1/auth/registrations",
       }
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   namespace :api, format: "json" do
     namespace :v1 do
       resources :articles
-      mount_devise_token_auth_for "User", at: "auth"
+      mount_devise_token_auth_for "User", at: "auth", controllers: {
+        registrations: 'api/v1/auth/registrations'
+      }
     end
   end
 end


### PR DESCRIPTION
## 作業概要
- ユーザー新規登録の endpoint が POST /api/v1/authになるようルーティングの変更
- registrationsコントローラーの実装
- devise_token_auth編集(リクエストごとにトークンを新しくしない・トークンの有効期限は一ヶ月)

## 動作イメージ
<img width="896" alt="スクリーンショット 2020-01-19 13 01 44" src="https://user-images.githubusercontent.com/50073648/72674700-11cb7d80-3abd-11ea-8413-76c6cb8a9550.png">
<img width="885" alt="スクリーンショット 2020-01-19 13 01 54" src="https://user-images.githubusercontent.com/50073648/72674701-12fcaa80-3abd-11ea-8ed9-b3fa6e1ecd9e.png">
