### PR TITLE
Task.9-2~5 ログイン関連テストの実装まで

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::ApiController < ApplicationController
   include DeviseTokenAuth::Concerns::SetUserByToken
 
-  def current_user
-    @current_user ||= User.first
-  end
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::ArticlesController < Api::V1::ApiController
   before_action :set_article, only: [:update, :destroy]
+  before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
     articles = Article.all

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
   def sign_up_params
     params.permit(:name, :email, :password, :password_confirmation)
-    end
+  end
 
   def account_update_params
     params.permit(:name, :email)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
 
   validates :name, presence: true

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
-    let(:headers) {current_user.create_new_auth_token}
+    let(:headers) { current_user.create_new_auth_token }
 
     it "記事のレコードが作成できる" do
       expect { subject }.to change { current_user.articles.count }.by(1)
@@ -63,7 +63,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
     let(:params) { { article: { body: Faker::Lorem.paragraph, created_at: Time.current } } }
     let(:current_user) { create(:user) }
-    let(:headers) {current_user.create_new_auth_token}
+    let(:headers) { current_user.create_new_auth_token }
 
     context "自分の記事を更新するとき" do
       let(:article) { create(:article, user: current_user) }
@@ -87,11 +87,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "DELETE /api/v1/articles/:id" do
-    subject { delete(api_v1_article_path(article.id),headers: headers) }
+    subject { delete(api_v1_article_path(article.id), headers: headers) }
 
     let!(:article) { create(:article, user: current_user) }
     let(:current_user) { create(:user) }
-    let(:headers){ current_user.create_new_auth_token }
+    let(:headers) { current_user.create_new_auth_token }
 
     context "自分の記事を削除するとき" do
       it "記事を削除できる" do

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -43,14 +43,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "POST /api/v1/articles" do
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
-
-    before do
-      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
-    end
+    let(:headers) {current_user.create_new_auth_token}
 
     it "記事のレコードが作成できる" do
       expect { subject }.to change { current_user.articles.count }.by(1)
@@ -62,14 +59,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "PATCH /api/v1/articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params) }
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
     let(:params) { { article: { body: Faker::Lorem.paragraph, created_at: Time.current } } }
     let(:current_user) { create(:user) }
-
-    before do
-      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
-    end
+    let(:headers) {current_user.create_new_auth_token}
 
     context "自分の記事を更新するとき" do
       let(:article) { create(:article, user: current_user) }
@@ -82,7 +76,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       end
     end
 
-    context "他のuserの記事を更新しようとるすとき" do
+    context "他のuserの記事を更新しようとするとき" do
       let(:other_user) { create(:user) }
       let(:article) { create(:article, user: other_user) }
 
@@ -93,14 +87,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "DELETE /api/v1/articles/:id" do
-    subject { delete(api_v1_article_path(article.id)) }
+    subject { delete(api_v1_article_path(article.id),headers: headers) }
 
     let!(:article) { create(:article, user: current_user) }
     let(:current_user) { create(:user) }
-
-    before do
-      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
-    end
+    let(:headers){ current_user.create_new_auth_token }
 
     context "自分の記事を削除するとき" do
       it "記事を削除できる" do

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "GET /api/v1/auth/registrations" do
+    it "works! (now write some real specs)" do
+      get api_v1_auth_registrations_index_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,10 +1,108 @@
 require 'rails_helper'
 
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
-  describe "GET /api/v1/auth/registrations" do
-    it "works! (now write some real specs)" do
-      get api_v1_auth_registrations_index_path
-      expect(response).to have_http_status(200)
+  describe "POST /api/v1/auth" do
+    subject { post(api_v1_user_registration_path, params: params) }
+
+    context "Signupに必要な情報が送られた時" do
+      let(:params) { attributes_for(:user) }
+
+      it "ユーザー登録できる" do
+        expect { subject }.to change { User.count }.by(1)
+        expect(response.headers["uid"]).to be_present
+        expect(response.headers["access-token"]).to be_present
+        expect(response.headers["client"]).to be_present
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "nameが入力されない場合" do
+      let(:params) { attributes_for(:user, name: nil) }
+
+      it "ユーザー登録されない" do
+        expect { subject }.to not_change { User.count }
+        expect(response.headers["uid"]).to be_blank
+        expect(response.headers["access-token"]).to be_blank
+        expect(response.headers["client"]).to be_blank
+      end
+    end
+
+    context "emailが入力されない場合" do
+      let(:params) { attributes_for(:user, email: nil) }
+
+      it "ユーザー登録されない" do
+        expect { subject }.to change { User.count }.by(0)
+        expect(response.headers["uid"]).to be_blank
+        expect(response.headers["access-token"]).to be_blank
+        expect(response.headers["client"]).to be_blank
+      end
+    end
+
+    context "passwordが入力されない場合" do
+      let(:params) { attributes_for(:user, password: nil) }
+
+      it "ユーザー登録されない" do
+        expect { subject }.to change { User.count }.by(0)
+        expect(response.headers["uid"]).to be_blank
+        expect(response.headers["access-token"]).to be_blank
+        expect(response.headers["client"]).to be_blank
+      end
+    end
+  end
+
+  describe "POST /api/v1/auth/sign_in" do
+    subject { post(api_v1_user_session_path, params: params) }
+
+    context "登録されているユーザーの必要な情報が正しく送信された時" do
+      let(:current_user) { create(:user) }
+      let(:params) { { email: current_user.email, password: current_user.password } }
+      it "ログインできる" do
+        subject
+        expect(response.headers["uid"]).to be_present
+        expect(response.headers["access-token"]).to be_present
+        expect(response.headers["client"]).to be_present
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "メールアドレスを間違えた場合" do
+      let(:current_user) { create(:user) }
+      let(:params) { { email: Faker::Internet.email, password: current_user.password } }
+      it "ログインできない" do
+        subject
+        expect(response.headers["uid"]).to be_blank
+        expect(response.headers["access-token"]).to be_blank
+        expect(response.headers["client"]).to be_blank
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "パスワードを間違えた場合" do
+      let(:current_user) { create(:user) }
+      let(:params) { { email: current_user.email, password: Faker::Internet.password } }
+      it "ログインできない" do
+        subject
+        expect(response.headers["uid"]).to be_blank
+        expect(response.headers["access-token"]).to be_blank
+        expect(response.headers["client"]).to be_blank
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/auth/sign_out" do
+    subject { delete(destroy_api_v1_user_session_path, headers: headers) }
+
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+
+    it "ログアウトできる" do
+      subject
+      expect(current_user.reload.tokens).to be_blank
+      expect(response.headers["uid"]).to be_blank
+      expect(response.headers["access-token"]).to be_blank
+      expect(response.headers["client"]).to be_blank
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   describe "POST /api/v1/auth" do

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   describe "POST /api/v1/auth" do
@@ -31,7 +31,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
       let(:params) { attributes_for(:user, email: nil) }
 
       it "ユーザー登録されない" do
-        expect { subject }.to change { User.count }.by(0)
+        expect { subject }.to not_change { User.count }
         expect(response.headers["uid"]).to be_blank
         expect(response.headers["access-token"]).to be_blank
         expect(response.headers["client"]).to be_blank
@@ -42,7 +42,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
       let(:params) { attributes_for(:user, password: nil) }
 
       it "ユーザー登録されない" do
-        expect { subject }.to change { User.count }.by(0)
+        expect { subject }.to not_change { User.count }
         expect(response.headers["uid"]).to be_blank
         expect(response.headers["access-token"]).to be_blank
         expect(response.headers["client"]).to be_blank


### PR DESCRIPTION
## 作業概要
- ログイン API・ログアウトAPIの実装と動作確認
- 既存 API の修正（ダミーのcurrent_user削除・テストにheader情報を渡し、create・update・deleteに関して要ログインに対応）
- Sign up・ログイン・ログアウトに関するrequest specを実装

## ログイン動作確認
<img width="888" alt="スクリーンショット 2020-01-19 21 25 10" src="https://user-images.githubusercontent.com/50073648/72682117-32bbbf00-3b0d-11ea-810a-9715dbea56ee.png">
<img width="888" alt="スクリーンショット 2020-01-19 21 25 21" src="https://user-images.githubusercontent.com/50073648/72682118-34858280-3b0d-11ea-83d5-a346cf6b6474.png">

## ログアウト動作確認
<img width="901" alt="スクリーンショット 2020-01-19 21 35 21" src="https://user-images.githubusercontent.com/50073648/72682146-6bf42f00-3b0d-11ea-96da-41a98765d83d.png">
<img width="884" alt="スクリーンショット 2020-01-19 21 35 33" src="https://user-images.githubusercontent.com/50073648/72682148-6d255c00-3b0d-11ea-9aee-7a601040dbfa.png">


