### PR TITLE
Task.11-2 既存のAPIの修正まで

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -3,12 +3,12 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
-    articles = Article.all
+    articles = Article.published
     render json: articles
   end
 
   def show
-    article = Article.find(params[:id])
+    article = Article.publiched.find(params[:id])
     render json: article
   end
 
@@ -30,7 +30,7 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   private
 
     def article_params
-      params.require(:article).permit(:title, :body)
+      params.require(:article).permit(:title, :body, :status)
     end
 
     def set_article

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   end
 
   def show
-    article = Article.publiched.find(params[:id])
+    article = Article.published.find(params[:id])
     render json: article
   end
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,6 +1,8 @@
 class Article < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
 
+  enum status: { draft: "draft", published: "published" }
+
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
   belongs_to :user

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,4 +1,4 @@
 class ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :updated_at, :status
   belongs_to :user
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   get "sign_in", to: "homes#index"
   get "articles/new", to: "homes#index"
   get "articles/:id", to: "homes#index"
-  
+
   namespace :api, format: "json" do
     namespace :v1 do
       resources :articles

--- a/db/migrate/20200120052050_add_status_to_articles.rb
+++ b/db/migrate/20200120052050_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :articles, :status, :string, default: "draft", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_08_070235) do
+ActiveRecord::Schema.define(version: 2020_01_20_052050) do
 
   create_table "article_likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2020_01_08_070235) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.string "status", default: "draft", null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -2,6 +2,11 @@ FactoryBot.define do
   factory :article do
     title { Faker::Lorem.characters(number: Random.new.rand(1..100)) }
     body { Faker::Lorem.paragraph }
+    status { :draft }
     user
+
+    trait :published_status do
+      status { :published }
+    end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -8,6 +8,22 @@ RSpec.describe Article, type: :model do
         expect(article).to be_valid
       end
     end
+
+    context "下書きとして投稿する場合" do
+      let(:article) { build(:article, status: "draft") }
+      it "下書き記事が投稿される" do
+        expect(article).to be_valid
+        expect(article.status).to eq "draft"
+      end
+    end
+
+    context "公開記事として投稿する場合" do
+      let(:article) { build(:article, status:　"published") }
+      it "公開記事が投稿される" do
+        expect(article).to be_valid
+        expect(article.status).to eq "published"
+      end
+    end
   end
 
   describe "異常系" do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Article, type: :model do
     end
 
     context "公開記事として投稿する場合" do
-      let(:article) { build(:article, status:　"published") }
+      let(:article) { build(:article, status: "published") }
       it "公開記事が投稿される" do
         expect(article).to be_valid
         expect(article.status).to eq "published"

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       subject
       res = JSON.parse(response.body)
       expect(res.length).to eq 3
-      expect(res[0].keys).to eq ["id", "title", "body", "user"]
+      expect(res[0].keys).to eq ["id", "title", "body", "updated_at","user"]
       expect(res[0]["user"].keys).to eq ["id", "name"]
       expect(response).to have_http_status(:ok)
     end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe "Api::V1::Articles", type: :request do
     subject { get(api_v1_articles_path) }
 
     before do
-      create_list(:article, 3)
+      create_list(:article, 3, :published_status)
     end
 
-    it "記事の一覧が取得できる" do
+    it "公開記事の一覧が取得できる" do
       subject
       res = JSON.parse(response.body)
       expect(res.length).to eq 3
-      expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "user"]
+      expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
       expect(res[0]["user"].keys).to eq ["id", "name"]
       expect(response).to have_http_status(:ok)
     end
@@ -21,9 +21,10 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /api/v1/articles/:id" do
     subject { get(api_v1_article_path(article_id)) }
 
-    context "指定したidの記事が存在する場合" do
-      let(:article) { create(:article) }
+    context "指定したidの記事が存在する場合（公開記事）" do
+      let(:article) { create(:article, :published_status) }
       let(:article_id) { article.id }
+
       it "指定した記事が取得できる" do
         subject
         res = JSON.parse(response.body)
@@ -31,6 +32,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
         expect(res["title"]).to eq article.title
         expect(res["body"]).to eq article.body
         expect(res["updated_at"]).to be_present
+        expect(res["status"]).to eq "published"
         expect(response).to have_http_status(:ok)
       end
     end
@@ -41,21 +43,43 @@ RSpec.describe "Api::V1::Articles", type: :request do
         expect { subject }.to raise_error ActiveRecord::RecordNotFound
       end
     end
+
+    context "記事が下書きの場合" do
+      let(:article) { create(:article) }
+      let(:article_id) { article.id }
+      it "記事が取得できない" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
   end
 
   describe "POST /api/v1/articles" do
     subject { post(api_v1_articles_path, params: params, headers: headers) }
-
-    let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
     let(:headers) { current_user.create_new_auth_token }
 
-    it "記事のレコードが作成できる" do
-      expect { subject }.to change { current_user.articles.count }.by(1)
-      res = JSON.parse(response.body)
-      expect(res["title"]).to eq params[:article][:title]
-      expect(res["body"]).to eq params[:article][:body]
-      expect(response).to have_http_status(:ok)
+    context "statusをpublishedにして投稿した場合" do
+      let(:params) { { article: attributes_for(:article, :published_status) } }
+
+      it "公開記事のレコードが作成できる" do
+        expect { subject }.to change { current_user.articles.count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["body"]).to eq params[:article][:body]
+        expect(res["status"]).to eq "published"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "statusをdraftで投稿した場合" do
+      let(:params) { { article: attributes_for(:article) } }
+
+      it "下書き設定の記事が作成できる" do
+        expect { subject }.to change { Article.count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq "draft"
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
   describe "POST /api/v1/articles" do
     subject { post(api_v1_articles_path, params: params, headers: headers) }
+
     let(:current_user) { create(:user) }
     let(:headers) { current_user.create_new_auth_token }
 

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       subject
       res = JSON.parse(response.body)
       expect(res.length).to eq 3
-      expect(res[0].keys).to eq ["id", "title", "body", "updated_at","user"]
+      expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "user"]
       expect(res[0]["user"].keys).to eq ["id", "name"]
       expect(response).to have_http_status(:ok)
     end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   describe "POST /api/v1/auth" do


### PR DESCRIPTION
## 作業概要
- 下書き(draft)と公開(published)の実装(enum)
- articles_controller.rbの修正(publishedのみ表示、statusの変更を許可)
- 下書き記事に関するテスト実装
